### PR TITLE
fix: render back-office through active parser so Smarty (default) works

### DIFF
--- a/Controller/ChronopostLabelController.php
+++ b/Controller/ChronopostLabelController.php
@@ -27,12 +27,11 @@ use Thelia\Model\OrderStatusQuery;
 use Thelia\Tools\DateTimeFormat;
 use Thelia\Tools\TokenProvider;
 use Thelia\Tools\URL;
-use Twig\Environment;
 
 class ChronopostLabelController extends BaseAdminController
 {
     #[Route('/admin/module/ChronopostLabel/labels', name: 'chronopost.label.labels', methods: ['GET'])]
-    public function showLabels(Request $request, Environment $twig): Response
+    public function showLabels(Request $request): Response
     {
         if (null !== $response = $this->checkAuth([AdminResources::MODULE], 'ChronopostLabel', AccessManager::VIEW)) {
             return $response;
@@ -69,7 +68,11 @@ class ChronopostLabelController extends BaseAdminController
             );
         }
 
-        return new Response($twig->render('@ChronopostLabelModule/backOffice/default-twig/ChronopostLabel/ChronopostLabels.html.twig', [
+        // Render through BaseAdminController so the active back-office template
+        // engine is resolved automatically: Smarty (default -> .html) or
+        // Twig (default-twig -> .html.twig). The Smarty template is self-sufficient
+        // (its own loops/forms) and ignores the args below, which feed the Twig one.
+        return $this->render('ChronopostLabel/ChronopostLabels', [
             'errors' => $errors,
             'home_delivery_activate' => $homeDeliveryModule,
             'pickup_point_activate' => $pickupPointModule,
@@ -78,7 +81,7 @@ class ChronopostLabelController extends BaseAdminController
             'home_orders' => $homeOrders,
             'pickup_orders' => $pickupOrders,
             'zip_hash' => $request->query->get('zip'),
-        ]));
+        ]);
     }
 
     /**

--- a/Hook/BackHook.php
+++ b/Hook/BackHook.php
@@ -39,14 +39,14 @@ class BackHook extends BaseHook
 
     public function onInTopMenuItem(HookRenderEvent $event): void
     {
-        $event->add($this->render('ChronopostLabel/hook/main-in-top-menu-items.html.twig', []));
+        $event->add($this->render($this->resolveTemplateName('ChronopostLabel/hook/main-in-top-menu-items'), []));
     }
 
     public function onModuleConfiguration(HookRenderEvent $event): void
     {
         $form = $this->formFactory->createForm(ChronopostLabelConfigurationForm::getName());
 
-        $event->add($this->render('ChronopostLabel/ChronopostLabelConfig.html.twig', [
+        $event->add($this->render($this->resolveTemplateName('ChronopostLabel/ChronopostLabelConfig'), [
             'form' => $form->createView()->getView(),
         ]));
     }
@@ -96,7 +96,7 @@ class BackHook extends BaseHook
             $destination = trim(sprintf('%s %s %s', $address->getAddress1(), $address->getCity(), $address->getZipcode()));
         }
 
-        $event->add($this->render('ChronopostLabel/hook/order-edit-bill-top.html.twig', [
+        $event->add($this->render($this->resolveTemplateName('ChronopostLabel/hook/order-edit-bill-top'), [
             'is_chronopost' => $isChronopost,
             'order_id' => $orderId,
             'label_nbr' => $labelNumber,
@@ -104,5 +104,16 @@ class BackHook extends BaseHook
             'create_date' => $createDate,
             'destination' => $destination,
         ]));
+    }
+
+    /**
+     * Append the current parser extension so the same hook serves the Smarty (default)
+     * and Twig (default-twig) back-office templates: Smarty -> ".html", Twig -> ".html.twig".
+     */
+    private function resolveTemplateName(string $baseName): string
+    {
+        $extension = ParserResolver::getCurrentParser()?->getFileExtension() ?? 'html';
+
+        return $baseName.'.'.$extension;
     }
 }

--- a/templates/backOffice/default/ChronopostLabel/ChronopostLabels.html
+++ b/templates/backOffice/default/ChronopostLabel/ChronopostLabels.html
@@ -126,11 +126,12 @@
                                                    href="{url path="/admin/module/ChronopostLabel/saveLabel" orderId=$ID}">
                                                     <span class="glyphicon glyphicon-floppy-disk"></span>
                                                 </a>
-                                                <a class="btn btn-danger btn-xs"
-                                                   title="{intl l='Delete this label' d='chronopostlabel.bo.default'}"
-                                                   href="{url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$ID redirect_url="/admin/module/ChronopostLabel/labels"}">
-                                                    <span class="glyphicon glyphicon-trash"></span>
-                                                </a>
+                                                <form method="post" class="chronopost-inline-form" action="{token_url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$ID redirect_url='/admin/module/ChronopostLabel/labels'}">
+                                                    <button type="submit" class="btn btn-danger btn-xs"
+                                                            title="{intl l='Delete this label' d='chronopostlabel.bo.default'}">
+                                                        <span class="glyphicon glyphicon-trash"></span>
+                                                    </button>
+                                                </form>
                                             {/if}
                                         </td>
                                     </tr>
@@ -212,11 +213,12 @@
                                                    href="{url path="/admin/module/ChronopostLabel/saveLabel" orderId=$ID}">
                                                     <span class="glyphicon glyphicon-floppy-disk"></span>
                                                 </a>
-                                                <a class="btn btn-danger btn-xs"
-                                                   title="{intl l='Delete this label' d='chronopostlabel.bo.default'}"
-                                                   href="{url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$ID redirect_url="/admin/module/ChronopostLabel/labels"}">
-                                                    <span class="glyphicon glyphicon-trash"></span>
-                                                </a>
+                                                <form method="post" class="chronopost-inline-form" action="{token_url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$ID redirect_url='/admin/module/ChronopostLabel/labels'}">
+                                                    <button type="submit" class="btn btn-danger btn-xs"
+                                                            title="{intl l='Delete this label' d='chronopostlabel.bo.default'}">
+                                                        <span class="glyphicon glyphicon-trash"></span>
+                                                    </button>
+                                                </form>
                                             {/if}
                                         </td>
                                     </tr>

--- a/templates/backOffice/default/ChronopostLabel/hook/order-edit-bill-top.html
+++ b/templates/backOffice/default/ChronopostLabel/hook/order-edit-bill-top.html
@@ -1,20 +1,4 @@
-{if $delivery_module == 'ChronopostHomeDelivery'}
-    {loop type='chronopost_label_home_delivery_export_loop' name='order_home_directory_label' order_id=$order_id}
-        {assign "label_nbr" $LABEL_NBR}
-        {assign "delivery_type" $DELIVERY_TYPE}
-    {/loop}
-{/if}
-
-{if $delivery_module == "ChronopostPickupPoint"}
-    {loop type='chronopost_label_pickup_point_export_loop' name='order_pickup_point_label' order_id=$order_id}
-        {assign "label_nbr" $LABEL_NBR}
-        {assign "delivery_type" $DELIVERY_TYPE}
-    {/loop}
-{/if}
-
-
-
-{if $delivery_module == "ChronopostPickupPoint" || $delivery_module == 'ChronopostHomeDelivery'}
+{if $is_chronopost}
     <br>
     <div class="title title-without-tabs clearfix">
         {intl l='Chronopost label' d='chronopostlabel.bo.default'}
@@ -30,12 +14,8 @@
         <tr>
             <td>{$label_nbr}</td>
             <td>{$delivery_type}</td>
-            {loop type="order" name="get-order-date" id=$order_id customer="*" backend_context="true"}
-            <td>{format_date date=$CREATE_DATE}</td>
-                {loop type="order_address" name="destination_loop" id=$DELIVERY_ADDRESS}
-                    <td>{$ADDRESS1} {$CITY} {$ZIPCODE}</td>
-                {/loop}
-            {/loop}
+            <td>{$create_date}</td>
+            <td>{$destination}</td>
             <td>
                 <a class="btn btn-primary pull-right {if !$label_nbr} disabled {/if}" href="{url path='/admin/module/ChronopostLabel/saveLabel' labelNbr=$label_nbr orderId=$order_id}">
                     {intl l='Download' d='chronopostlabel.bo.default'}
@@ -43,13 +23,17 @@
                 <a class="btn btn-info pull-right {if !$label_nbr} disabled {/if}" href={url path="/admin/module/ChronopostLabel/getLabel/{$order_id}"}>
                     {intl l='View' d='chronopostlabel.bo.default'}
                 </a>
-                <a class="btn btn-danger pull-right {if !$label_nbr} disabled {/if}" href="{url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$order_id redirect_url="/admin/order/update/$order_id"} ">
-                    {intl l='Delete' d='chronopostlabel.bo.default'}
-                </a>
+                <form method="post" class="pull-right" action="{token_url path='/admin/module/ChronopostLabel/deleteLabel' orderId=$order_id redirect_url="/admin/order/update/$order_id"}">
+                    <button type="submit" class="btn btn-danger {if !$label_nbr} disabled {/if}">
+                        {intl l='Delete' d='chronopostlabel.bo.default'}
+                    </button>
+                </form>
                 {if !$label_nbr}
-                    <a class="btn btn-primary pull-right" href={url path="/admin/module/ChronopostLabel/generateLabel" orderId=$order_id}>
-                        {intl l='Generate' d='chronopostlabel.bo.default'}
-                    </a>
+                    <form method="post" class="pull-right" action="{token_url path='/admin/module/ChronopostLabel/generateLabel' orderId=$order_id}">
+                        <button type="submit" class="btn btn-primary">
+                            {intl l='Generate' d='chronopostlabel.bo.default'}
+                        </button>
+                    </form>
                 {/if}
             </td>
         </tr>


### PR DESCRIPTION
The modernized back-office forced Twig rendering (assignToken() Twig function, @ChronopostLabelModule Twig namespace), which only exists when the active admin template is default-twig. On a Smarty (default) back office it broke with 'Unknown assignToken function'.

- Controller: render 'ChronopostLabel/ChronopostLabels' via BaseAdminController so the parser/extension is resolved from the active template (Smarty -> .html, Twig -> .html.twig).
- BackHook: resolveTemplateName() appends the active parser extension for the menu, config and order-edit hooks.
- Smarty templates: deleteLabel/generateLabel switched from GET links to POST forms with {token_url} to match the CSRF-hardened routes.